### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_classifier/api.py
+++ b/invenio_classifier/api.py
@@ -26,7 +26,7 @@ import re
 
 from flask import current_app
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.utils.filedownload import download_url
 
 from .engine import (

--- a/invenio_classifier/engine.py
+++ b/invenio_classifier/engine.py
@@ -27,7 +27,7 @@ from __future__ import print_function
 
 import os
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.utils.text import encode_for_xml
 
 from six import iteritems

--- a/invenio_classifier/keyworder.py
+++ b/invenio_classifier/keyworder.py
@@ -31,7 +31,7 @@ import time
 
 from flask import current_app
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 
 from .errors import OntologyError
 

--- a/invenio_classifier/manage.py
+++ b/invenio_classifier/manage.py
@@ -98,7 +98,7 @@ def extract(filepath, taxonomy, output, limit,
 
 def main():
     """Run manager."""
-    from invenio.base.factory import create_app
+    from invenio_base.factory import create_app
     app = create_app()
     manager.app = app
     manager.run()

--- a/invenio_classifier/reader.py
+++ b/invenio_classifier/reader.py
@@ -43,7 +43,7 @@ from datetime import datetime, timedelta
 
 from flask import current_app
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.utils.url import make_invenio_opener
 
 import rdflib

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,5 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-base>=0.2.1',
     # FIXME 'Invenio>=2.0.3',
 ]
 
@@ -50,6 +51,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -54,7 +54,7 @@ class ClassifierTestCase(InvenioTestCase):
 
     @property
     def config(self):
-        from invenio.base.config import PACKAGES
+        from invenio_base.config import PACKAGES
         default_config = super(ClassifierTestCase, self).config
         default_config["PACKAGES"] = PACKAGES + ["invenio_classifier"]
         return default_config


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past upgrade
  recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>