### PR TITLE
tests: fix pytest >=2.8.0 breaking

### DIFF
--- a/.travis.invenio.cfg
+++ b/.travis.invenio.cfg
@@ -30,6 +30,6 @@ SECRET_KEY = 'MY_SECRET'
 ASSETS_AUTO_BUILD = False
 
 PACKAGES = [
-    'invenio_testing',
+    'invenio_records',
     'invenio_base',
 ]

--- a/.travis.invenio.cfg
+++ b/.travis.invenio.cfg
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Travis-CI configuration."""
+
+import getpass
+
+CFG_BIBSCHED_PROCESS_USER = getpass.getuser()
+
+DEBUG = False
+SECRET_KEY = 'MY_SECRET'
+
+# Disable all automatic asset building - false is /usr/bin/false.
+ASSETS_AUTO_BUILD = False
+
+PACKAGES = [
+    'invenio_testing',
+    'invenio_base',
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ python:
 
 before_install:
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock twine wheel"
+  - "travis_retry pip install check-manifest mock twine wheel"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -62,6 +62,7 @@ before_script:
   - "inveniomanage database create --quiet || echo ':('"
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,12 @@ python:
 
 before_install:
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install check-manifest mock twine wheel"
+  - "travis_retry pip install check-manifest mock twine wheel coveralls"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
+  - "mkdir -p ${VIRTUAL_ENV}/var/invenio.base-instance/"
+  - "cp .travis.invenio.cfg ${VIRTUAL_ENV}/var/invenio.base-instance/invenio.cfg"
 
 install:
   - "travis_retry pip install Invenio"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include *.py
 include *.rst
 include *.txt
-include .dockerignore .editorconfig
+include .dockerignore .editorconfig .travis.invenio.cfg
 include LICENSE
 include babel.ini
 include pytest.ini

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_classifier --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_classifier --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,13 +21,8 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-#
-# TODO: Add development versions of some important dependencies here to get a
-#       warning when there are breaking upstream changes, e.g.:
-#
-#     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
-#     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext
+-e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
 -e git+git://github.com/inveniosoftware/invenio-utils.git#egg=invenio-utils

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
-    'invenio-base>=0.2.1',
+    'invenio-base>=0.3.1',
     'invenio-ext>=0.2.1',
     'invenio-utils>=0.1.1',
 ]

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,10 @@ requirements = [
 test_requirements = [
     'unittest2>=1.1.0',
     'Flask-Testing>=0.4.2',
-    'pytest>=2.7.0',
-    'pytest-cov>=1.8.0',
+    'pytest>=2.8.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'coverage>=3.7.1',
+    'coverage>=4.0.0',
 ]
 
 
@@ -79,9 +79,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ requirements = [
     'six>=1.7.2',
     'invenio-base>=0.3.1',
     'invenio-ext>=0.2.1',
+    'invenio-records>=0.3.3',
     'invenio-utils>=0.1.1',
 ]
 
@@ -49,7 +50,6 @@ test_requirements = [
     'pytest-pep8>=1.0.6',
     'coverage>=4.0.0',
     'invenio-testing>=0.1.1',
-
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
     'invenio-base>=0.3.1',
-    'invenio-ext>=0.2.1',
+    'invenio-ext>=0.3.1',
     'invenio-records>=0.3.3',
     'invenio-utils>=0.1.1',
 ]

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ requirements = [
     'invenio-base>=0.3.1',
     'invenio-ext>=0.3.1',
     'invenio-records>=0.3.3',
-    'invenio-utils>=0.1.1',
+    'invenio-utils>=0.2.0',
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ test_requirements = [
     'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
     'coverage>=4.0.0',
+    'invenio-testing>=0.1.1',
+
 ]
 
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -29,11 +29,7 @@ from flask_registry import (
     PkgResourcesDirDiscoveryRegistry,
     RegistryProxy,
 )
-from invenio.testsuite import (
-    InvenioTestCase,
-    make_test_suite,
-    run_test_suite,
-)
+from invenio_testing import InvenioTestCase
 
 
 def _get_test_taxonomies():
@@ -251,10 +247,3 @@ class ClassifierTest(ClassifierTestCase):
         cache = reader._get_cache_path(name)
         os.remove(taxonomy_path)
         os.remove(cache)
-
-
-TEST_SUITE = make_test_suite(ClassifierTest)
-
-
-if __name__ == '__main__':
-    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
* FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>