### PR TITLE
keyworder: find combinations even if components are not found

### DIFF
--- a/invenio_classifier/keyworder.py
+++ b/invenio_classifier/keyworder.py
@@ -148,7 +148,7 @@ def get_composite_keywords(ckw_db, fulltext, skw_spans):
         except KeyError:
             # Some of the keyword components are not to be found in the text.
             # Therefore we cannot continue because the match is incomplete.
-            continue
+            pass
 
         ckw_spans = []
         for index in range(len(spans) - 1):


### PR DESCRIPTION
* Removes a bug in bibclassify_keyword_analyzer.py. If a combination
  is found via a synonym or regexp it is no longer thrown away just
  because the components of the combination are not found in the text.

Signed-off-by: fschwenn florian.schwennsen@desy.de