### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,8 +184,8 @@ language.
 Happy hacking and thanks for flying Invenio-Classifier.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-classifier
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Classifier.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-classifier
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/invenio_classifier/regexs.py
+++ b/invenio_classifier/regexs.py
@@ -306,12 +306,12 @@ raw_url_pattern = r"""
         (https?|s?ftp)://(?:[\w\d_.-])+(?::\d{1,5})?
         (?:/[\w\d_.?=&%~∼-]+)*/?
 """
-# Stand-alone URL (e.g. http://invenio-software.org/ )
+# Stand-alone URL (e.g. http://inveniosoftware.org/ )
 re_raw_url = \
     re.compile("['\"]?(?P<url>" + raw_url_pattern + ")['\"]?",
                re.UNICODE | re.I | re.VERBOSE)
 
-# HTML marked-up URL (e.g. <a href="http://invenio-software.org/">
+# HTML marked-up URL (e.g. <a href="http://inveniosoftware.org/">
 # CERN Document Server Software Consortium</a> )
 re_html_tagged_url = \
     re.compile(r"""

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     keywords='invenio TODO',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-classifier',
     packages=packages,
     zip_safe=False,


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>