### PR TITLE
fix python3: compositeof being overwritten

### DIFF
--- a/invenio_classifier/reader.py
+++ b/invenio_classifier/reader.py
@@ -439,10 +439,8 @@ class KeywordToken(object):
         """
 
         def _get_ckw_components(new_vals, label):
-
             if isinstance(label, KeywordToken):
                 label = label.short_id
-
 
             if label in single_keywords:
                 new_vals.append(single_keywords[label])


### PR DESCRIPTION
* ref: cern-sis/issues-inspire/issues/1122